### PR TITLE
Fix Go version syntax in SonarQube workflow

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-        go-version: '1.23.x'
+          go-version: '1.23'
 
       - name: Run unit Tests
         run: |


### PR DESCRIPTION
Corrected the Go version syntax from '1.23.x' to '1.23' in the SonarQube GitHub Action workflow configuration to ensure proper version setup. This change addresses potential issues with version resolution in the setup-go action.