### PR TITLE
Refactor error messages in niljson tests.

### DIFF
--- a/niljson_test.go
+++ b/niljson_test.go
@@ -12,11 +12,15 @@ import (
 	"testing"
 )
 
+// List of common errors
 const (
 	ErrUnmarshalFailed    = "failed to unmarshal json with nil types: %s"
 	ErrMarshalFailed      = "failed to marshal json with nil types: %s"
 	ErrExpectedJSONString = "expected json to be %q, got %q"
 	ErrExpectedJSONInt    = "expected json to be %d, got %d"
+	ErrExpectedValue      = "expected value, but got nil"
+	ErrExpectedNil        = "expected nil, but got value"
+	ErrExpectedNilReset   = "expected value to be nil after reset"
 )
 
 var jsonBytes = []byte(
@@ -48,10 +52,10 @@ func TestVariable_UnmarshalJSON_Boolean(t *testing.T) {
 	}
 
 	if jt.Value.IsNil() {
-		t.Errorf("expected value, but got nil")
+		t.Errorf(ErrExpectedValue)
 	}
 	if jt.NilValue.NotNil() {
-		t.Errorf("expected nil, but got value")
+		t.Errorf(ErrExpectedNil)
 	}
 	if !jt.Value.Value() {
 		t.Errorf("expected value to be true, got %t", jt.Value.Value())
@@ -59,7 +63,7 @@ func TestVariable_UnmarshalJSON_Boolean(t *testing.T) {
 
 	jt.Value.Reset()
 	if jt.Value.NotNil() {
-		t.Errorf("expected value to be nil after reset")
+		t.Errorf(ErrExpectedNilReset)
 	}
 }
 
@@ -94,10 +98,10 @@ func TestVariable_UnmarshalJSON_ByteSlice(t *testing.T) {
 	}
 
 	if jt.Value.IsNil() {
-		t.Errorf("expected value, but got nil")
+		t.Errorf(ErrExpectedValue)
 	}
 	if jt.NilValue.NotNil() {
-		t.Errorf("expected nil, but got value")
+		t.Errorf(ErrExpectedNil)
 	}
 	if !bytes.Equal(jt.Value.Value(), []byte("bytes")) {
 		t.Errorf("expected value to be %q, got %q", "bytes", jt.Value.Value())
@@ -105,7 +109,7 @@ func TestVariable_UnmarshalJSON_ByteSlice(t *testing.T) {
 
 	jt.Value.Reset()
 	if jt.Value.NotNil() {
-		t.Errorf("expected value to be nil after reset")
+		t.Errorf(ErrExpectedNilReset)
 	}
 }
 
@@ -141,10 +145,10 @@ func TestVariable_UnmarshalJSON_Float32(t *testing.T) {
 	}
 
 	if jt.Value.IsNil() {
-		t.Errorf("expected value, but got nil")
+		t.Errorf(ErrExpectedValue)
 	}
 	if jt.NilValue.NotNil() {
-		t.Errorf("expected nil, but got value")
+		t.Errorf(ErrExpectedNil)
 	}
 	if jt.Value.Value() != expected {
 		t.Errorf("expected value to be %f, got %f", expected, jt.Value.Value())
@@ -152,7 +156,7 @@ func TestVariable_UnmarshalJSON_Float32(t *testing.T) {
 
 	jt.Value.Reset()
 	if jt.Value.NotNil() {
-		t.Errorf("expected value to be nil after reset")
+		t.Errorf(ErrExpectedNilReset)
 	}
 }
 
@@ -188,10 +192,10 @@ func TestVariable_UnmarshalJSON_Float64(t *testing.T) {
 	}
 
 	if jt.Value.IsNil() {
-		t.Errorf("expected value, but got nil")
+		t.Errorf(ErrExpectedValue)
 	}
 	if jt.NilValue.NotNil() {
-		t.Errorf("expected nil, but got value")
+		t.Errorf(ErrExpectedNil)
 	}
 	if jt.Value.Value() != expected {
 		t.Errorf("expected value to be %f, got %f", expected, jt.Value.Value())
@@ -199,7 +203,7 @@ func TestVariable_UnmarshalJSON_Float64(t *testing.T) {
 
 	jt.Value.Reset()
 	if jt.Value.NotNil() {
-		t.Errorf("expected value to be nil after reset")
+		t.Errorf(ErrExpectedNilReset)
 	}
 }
 
@@ -235,10 +239,10 @@ func TestVariable_UnmarshalJSON_Int(t *testing.T) {
 	}
 
 	if jt.Value.IsNil() {
-		t.Errorf("expected value, but got nil")
+		t.Errorf(ErrExpectedValue)
 	}
 	if jt.NilValue.NotNil() {
-		t.Errorf("expected nil, but got value")
+		t.Errorf(ErrExpectedNil)
 	}
 	if jt.Value.Value() != expected {
 		t.Errorf(ErrExpectedJSONInt, expected, jt.Value.Value())
@@ -246,7 +250,7 @@ func TestVariable_UnmarshalJSON_Int(t *testing.T) {
 
 	jt.Value.Reset()
 	if jt.Value.NotNil() {
-		t.Errorf("expected value to be nil after reset")
+		t.Errorf(ErrExpectedNilReset)
 	}
 }
 
@@ -282,10 +286,10 @@ func TestVariable_UnmarshalJSON_Int64(t *testing.T) {
 	}
 
 	if jt.Value.IsNil() {
-		t.Errorf("expected value, but got nil")
+		t.Errorf(ErrExpectedValue)
 	}
 	if jt.NilValue.NotNil() {
-		t.Errorf("expected nil, but got value")
+		t.Errorf(ErrExpectedNil)
 	}
 	if jt.Value.Value() != expected {
 		t.Errorf(ErrExpectedJSONInt, expected, jt.Value.Value())
@@ -293,7 +297,7 @@ func TestVariable_UnmarshalJSON_Int64(t *testing.T) {
 
 	jt.Value.Reset()
 	if jt.Value.NotNil() {
-		t.Errorf("expected value to be nil after reset")
+		t.Errorf(ErrExpectedNilReset)
 	}
 }
 
@@ -329,10 +333,10 @@ func TestVariable_UnmarshalJSON_String(t *testing.T) {
 	}
 
 	if jt.Value.IsNil() {
-		t.Errorf("expected value, but got nil")
+		t.Errorf(ErrExpectedValue)
 	}
 	if jt.NilValue.NotNil() {
-		t.Errorf("expected nil, but got value")
+		t.Errorf(ErrExpectedNil)
 	}
 	if jt.Value.Value() != expected {
 		t.Errorf("expected value to be %s, got %s", expected, jt.Value.Value())
@@ -340,7 +344,7 @@ func TestVariable_UnmarshalJSON_String(t *testing.T) {
 
 	jt.Value.Reset()
 	if jt.Value.NotNil() {
-		t.Errorf("expected value to be nil after reset")
+		t.Errorf(ErrExpectedNilReset)
 	}
 }
 
@@ -376,10 +380,10 @@ func TestVariable_UnmarshalJSON_UInt(t *testing.T) {
 	}
 
 	if jt.Value.IsNil() {
-		t.Errorf("expected value, but got nil")
+		t.Errorf(ErrExpectedValue)
 	}
 	if jt.NilValue.NotNil() {
-		t.Errorf("expected nil, but got value")
+		t.Errorf(ErrExpectedNil)
 	}
 	if jt.Value.Value() != expected {
 		t.Errorf(ErrExpectedJSONInt, expected, jt.Value.Value())
@@ -387,7 +391,7 @@ func TestVariable_UnmarshalJSON_UInt(t *testing.T) {
 
 	jt.Value.Reset()
 	if jt.Value.NotNil() {
-		t.Errorf("expected value to be nil after reset")
+		t.Errorf(ErrExpectedNilReset)
 	}
 }
 
@@ -423,10 +427,10 @@ func TestVariable_UnmarshalJSON_UInt8(t *testing.T) {
 	}
 
 	if jt.Value.IsNil() {
-		t.Errorf("expected value, but got nil")
+		t.Errorf(ErrExpectedValue)
 	}
 	if jt.NilValue.NotNil() {
-		t.Errorf("expected nil, but got value")
+		t.Errorf(ErrExpectedNil)
 	}
 	if jt.Value.Value() != expected {
 		t.Errorf(ErrExpectedJSONInt, expected, jt.Value.Value())
@@ -434,7 +438,7 @@ func TestVariable_UnmarshalJSON_UInt8(t *testing.T) {
 
 	jt.Value.Reset()
 	if jt.Value.NotNil() {
-		t.Errorf("expected value to be nil after reset")
+		t.Errorf(ErrExpectedNilReset)
 	}
 }
 
@@ -470,10 +474,10 @@ func TestVariable_UnmarshalJSON_UInt16(t *testing.T) {
 	}
 
 	if jt.Value.IsNil() {
-		t.Errorf("expected value, but got nil")
+		t.Errorf(ErrExpectedValue)
 	}
 	if jt.NilValue.NotNil() {
-		t.Errorf("expected nil, but got value")
+		t.Errorf(ErrExpectedNil)
 	}
 	if jt.Value.Value() != expected {
 		t.Errorf(ErrExpectedJSONInt, expected, jt.Value.Value())
@@ -481,7 +485,7 @@ func TestVariable_UnmarshalJSON_UInt16(t *testing.T) {
 
 	jt.Value.Reset()
 	if jt.Value.NotNil() {
-		t.Errorf("expected value to be nil after reset")
+		t.Errorf(ErrExpectedNilReset)
 	}
 }
 
@@ -517,10 +521,10 @@ func TestVariable_UnmarshalJSON_UInt32(t *testing.T) {
 	}
 
 	if jt.Value.IsNil() {
-		t.Errorf("expected value, but got nil")
+		t.Errorf(ErrExpectedValue)
 	}
 	if jt.NilValue.NotNil() {
-		t.Errorf("expected nil, but got value")
+		t.Errorf(ErrExpectedNil)
 	}
 	if jt.Value.Value() != expected {
 		t.Errorf(ErrExpectedJSONInt, expected, jt.Value.Value())
@@ -528,7 +532,7 @@ func TestVariable_UnmarshalJSON_UInt32(t *testing.T) {
 
 	jt.Value.Reset()
 	if jt.Value.NotNil() {
-		t.Errorf("expected value to be nil after reset")
+		t.Errorf(ErrExpectedNilReset)
 	}
 }
 
@@ -564,10 +568,10 @@ func TestVariable_UnmarshalJSON_UInt64(t *testing.T) {
 	}
 
 	if jt.Value.IsNil() {
-		t.Errorf("expected value, but got nil")
+		t.Errorf(ErrExpectedValue)
 	}
 	if jt.NilValue.NotNil() {
-		t.Errorf("expected nil, but got value")
+		t.Errorf(ErrExpectedNil)
 	}
 	if jt.Value.Value() != expected {
 		t.Errorf(ErrExpectedJSONInt, expected, jt.Value.Value())
@@ -575,7 +579,7 @@ func TestVariable_UnmarshalJSON_UInt64(t *testing.T) {
 
 	jt.Value.Reset()
 	if jt.Value.NotNil() {
-		t.Errorf("expected value to be nil after reset")
+		t.Errorf(ErrExpectedNilReset)
 	}
 }
 


### PR DESCRIPTION
Replaced hard-coded error strings with constant variables to improve code maintenance and readability. This ensures consistency across error messages and makes future updates easier.