### PR TITLE
Add omitted functionallity

### DIFF
--- a/niljson.go
+++ b/niljson.go
@@ -51,17 +51,17 @@ type Variable[T any] struct {
 	present bool
 }
 
-// IsNil returns true when a Variable is nil
-func (v *Variable[T]) IsNil() bool {
-	return !v.notNil
-}
-
 // NewVariable returns a new Variable of generic type
 func NewVariable[T any](value T) Variable[T] {
 	return Variable[T]{
 		notNil: true,
 		value:  value,
 	}
+}
+
+// IsNil returns true when a Variable is nil
+func (v *Variable[T]) IsNil() bool {
+	return !v.notNil
 }
 
 // NotNil returns true when a Variable is not nil

--- a/niljson.go
+++ b/niljson.go
@@ -69,8 +69,8 @@ func (v *Variable[T]) NotNil() bool {
 	return v.notNil
 }
 
-// Ommited returns true if a value was omitted in the JSON
-func (v *Variable[T]) Ommited() bool {
+// Omitted returns true if a value was omitted in the JSON
+func (v *Variable[T]) Omitted() bool {
 	return !v.present
 }
 

--- a/niljson.go
+++ b/niljson.go
@@ -10,13 +10,22 @@ import (
 
 // Variable is a generic variable type that can be null.
 type Variable[T any] struct {
-	value  T
-	notNil bool
+	value   T
+	notNil  bool
+	present bool
 }
 
-// Value returns the value of the Variable
-func (v *Variable[T]) Value() T {
-	return v.value
+// IsNil returns true when a Variable is nil
+func (v *Variable[T]) IsNil() bool {
+	return !v.notNil
+}
+
+// NewVariable returns a new Variable of generic type
+func NewVariable[T any](value T) Variable[T] {
+	return Variable[T]{
+		notNil: true,
+		value:  value,
+	}
 }
 
 // NotNil returns true when a Variable is not nil
@@ -24,9 +33,9 @@ func (v *Variable[T]) NotNil() bool {
 	return v.notNil
 }
 
-// IsNil returns true when a Variable is nil
-func (v *Variable[T]) IsNil() bool {
-	return !v.notNil
+// Ommited returns true if a value was omitted in the JSON
+func (v *Variable[T]) Ommited() bool {
+	return !v.present
 }
 
 // Reset resets the value to the Variable to a zero value and sets it to be nil
@@ -36,12 +45,9 @@ func (v *Variable[T]) Reset() {
 	v.notNil = false
 }
 
-// NewVariable returns a new Variable of generic type
-func NewVariable[T any](value T) Variable[T] {
-	return Variable[T]{
-		notNil: true,
-		value:  value,
-	}
+// Value returns the value of the Variable
+func (v *Variable[T]) Value() T {
+	return v.value
 }
 
 // NilBoolean is an boolean type that can be nil
@@ -82,6 +88,7 @@ type NilString = Variable[string]
 
 // UnmarshalJSON satisfies the json.Unmarshaler interface for generic Variable types
 func (v *Variable[T]) UnmarshalJSON(data []byte) error {
+	v.present = true
 	if string(data) != "null" {
 		v.value = *new(T)
 		v.notNil = true

--- a/niljson.go
+++ b/niljson.go
@@ -8,6 +8,42 @@ import (
 	"encoding/json"
 )
 
+// NilBoolean is an boolean type that can be nil
+type NilBoolean = Variable[bool]
+
+// NilByteSlice is a []byte type that can be nil
+type NilByteSlice = Variable[[]byte]
+
+// NilInt is an int type that can be nil
+type NilInt = Variable[int]
+
+// NilInt64 is an int64 type that can be nil
+type NilInt64 = Variable[int64]
+
+// NilUInt is an uint type that can be nil
+type NilUInt = Variable[uint]
+
+// NilUInt8 is an uint8 type that can be nil
+type NilUInt8 = Variable[uint8]
+
+// NilUInt16 is an uint16 type that can be nil
+type NilUInt16 = Variable[uint16]
+
+// NilUInt32 is an uint32 type that can be nil
+type NilUInt32 = Variable[uint32]
+
+// NilUInt64 is an uint64 type that can be nil
+type NilUInt64 = Variable[uint64]
+
+// NilFloat32 is an float32 type that can be nil
+type NilFloat32 = Variable[float32]
+
+// NilFloat64 is an float64 type that can be nil
+type NilFloat64 = Variable[float64]
+
+// NilString is a string type that can be nil
+type NilString = Variable[string]
+
 // Variable is a generic variable type that can be null.
 type Variable[T any] struct {
 	value   T
@@ -50,41 +86,13 @@ func (v *Variable[T]) Value() T {
 	return v.value
 }
 
-// NilBoolean is an boolean type that can be nil
-type NilBoolean = Variable[bool]
-
-// NilByteSlice is a []byte type that can be nil
-type NilByteSlice = Variable[[]byte]
-
-// NilInt is an int type that can be nil
-type NilInt = Variable[int]
-
-// NilInt64 is an int64 type that can be nil
-type NilInt64 = Variable[int64]
-
-// NilUInt is an uint type that can be nil
-type NilUInt = Variable[uint]
-
-// NilUInt8 is an uint8 type that can be nil
-type NilUInt8 = Variable[uint8]
-
-// NilUInt16 is an uint16 type that can be nil
-type NilUInt16 = Variable[uint16]
-
-// NilUInt32 is an uint32 type that can be nil
-type NilUInt32 = Variable[uint32]
-
-// NilUInt64 is an uint64 type that can be nil
-type NilUInt64 = Variable[uint64]
-
-// NilFloat32 is an float32 type that can be nil
-type NilFloat32 = Variable[float32]
-
-// NilFloat64 is an float64 type that can be nil
-type NilFloat64 = Variable[float64]
-
-// NilString is a string type that can be nil
-type NilString = Variable[string]
+// MarshalJSON satisfies the json.Marshaler interface for generic Variable types
+func (v *Variable[T]) MarshalJSON() ([]byte, error) {
+	if !v.notNil {
+		return json.Marshal(nil)
+	}
+	return json.Marshal(v.value)
+}
 
 // UnmarshalJSON satisfies the json.Unmarshaler interface for generic Variable types
 func (v *Variable[T]) UnmarshalJSON(data []byte) error {
@@ -95,12 +103,4 @@ func (v *Variable[T]) UnmarshalJSON(data []byte) error {
 		return json.Unmarshal(data, &v.value)
 	}
 	return nil
-}
-
-// MarshalJSON satisfies the json.Marshaler interface for generic Variable types
-func (v *Variable[T]) MarshalJSON() ([]byte, error) {
-	if !v.notNil {
-		return json.Marshal(nil)
-	}
-	return json.Marshal(v.value)
 }

--- a/niljson_test.go
+++ b/niljson_test.go
@@ -602,6 +602,28 @@ func TestVariable_MarshalJSON_UInt64(t *testing.T) {
 	}
 }
 
+func TestVariable_Omitted(t *testing.T) {
+	type JSONType struct {
+		NilValue NilBoolean `json:"nilvalue"`
+		Omitted  NilBoolean `json:"omitted,omitempty"`
+	}
+
+	var jt JSONType
+	if err := json.Unmarshal(jsonBytes, &jt); err != nil {
+		t.Errorf(ErrUnmarshalFailed, err)
+	}
+
+	if jt.NilValue.NotNil() {
+		t.Error(ErrExpectedNil)
+	}
+	if jt.NilValue.Omitted() {
+		t.Error("expected nil value to be not omitted")
+	}
+	if !jt.Omitted.Omitted() {
+		t.Error("expected omitted value to be omitted")
+	}
+}
+
 func ExampleVariable_UnmarshalJSON() {
 	type JSONType struct {
 		Bool       NilBoolean   `json:"bool"`


### PR DESCRIPTION
This PR adds the `Omitted()` methods which allows the user to identify if a `null` JSON value was sent as actual `null` or was completely omitted from the JSON. This can be helpful in case the JSON requires some mandatory fields.