### PR TITLE
Set permissions to read for workflow

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -6,6 +6,9 @@ name: REUSE Compliance Check
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add 'contents: read' permissions to the GitHub Actions workflow configuration. This change enhances security by only allowing read access to the repository contents.

Fixed #18 