### PR TITLE
Add SECURITY.md for reporting vulnerabilities

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+<!--
+SPDX-FileCopyrightText: 2024 Winni Neessen <wn@neessen.dev>
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report (possible) security issues in niljson, please either send a mail to 
+[wn@neessen.dev](mailto:wn@neessen.dev) or use Github's 
+[private reporting feature](https://github.com/wneessen/niljson/security/advisories/new).
+Reports are always welcome. Even if you are not 100% certain that a specific issue you found
+counts as a security issue, we'd love to hear the details, so we can figure out together if
+the issue in question needds to be addressed.
+
+Typically, you will receive an answer within a day or even within a few hours.
+
+## Encryption
+You can send OpenPGP/GPG encrpyted mails to the [wn@neessen.dev](mailto:wn@neessen.dev) address.
+
+OpenPGP/GPG public key:
+```
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+xjMEY8XedRYJKwYBBAHaRw8BAQdAVPb7jn5V7TPWh7lODBPm9SOgS568Plsk
+prDUK/kZWiTNH3duQG5lZXNzZW4uZGV2IDx3bkBuZWVzc2VuLmRldj7CjAQQ
+FgoAPgUCY8XedQQLCQcICRC0L3U6o8fYrQMVCAoEFgACAQIZAQIbAwIeARYh
+BK6dDe0sVXaVAlOuqrQvdTqjx9itAACfPAEAs1SvBmpVk540On+UEdHCbzP0
+aD7bngxm2pUe4+ynzCMBAMt1bZSRaRzItYxiJvXzYH48Z9J6n06eWQbr7wwe
+YBEDzjgEY8XedRIKKwYBBAGXVQEFAQEHQGTblfiuHDaOL72GnBpKTl4dJqxs
+g0ZfOmD2Sfrmdd89AwEIB8J4BBgWCAAqBQJjxd51CRC0L3U6o8fYrQIbDBYh
+BK6dDe0sVXaVAlOuqrQvdTqjx9itAADFrAD8D54IStjrrHlH1cpKCkW60mMB
+Rsn++p/UorLoKfhQa3IA/3p3lWhGZ1RYfj35oFGh2bBu1NYDFr5RPYu2dDsO
+D10A
+=EyfK
+-----END PGP PUBLIC KEY BLOCK-----
+```


### PR DESCRIPTION
Created a SECURITY.md file detailing how to report possible vulnerabilities in the project. Includes contact information, response expectations, and instructions for sending encrypted reports using OpenPGP/GPG.