### PR TITLE
Add `Set` method for Variable and associated test case

### DIFF
--- a/niljson.go
+++ b/niljson.go
@@ -86,6 +86,13 @@ func (v *Variable[T]) Value() T {
 	return v.value
 }
 
+// Set makes the Variable valid with the given value
+func (v *Variable[T]) Set(val T) {
+	v.value = val
+	v.present = true
+	v.notNil = true
+}
+
 // MarshalJSON satisfies the json.Marshaler interface for generic Variable types
 func (v *Variable[T]) MarshalJSON() ([]byte, error) {
 	if !v.notNil {

--- a/niljson_test.go
+++ b/niljson_test.go
@@ -624,6 +624,30 @@ func TestVariable_Omitted(t *testing.T) {
 	}
 }
 
+func TestVariable_Set(t *testing.T) {
+	type JSONType struct {
+		Value NilString `json:"non_existing"`
+	}
+	expected := "test"
+
+	var jt JSONType
+	if err := json.Unmarshal(jsonBytes, &jt); err != nil {
+		t.Errorf(ErrUnmarshalFailed, err)
+	}
+
+	if jt.Value.NotNil() {
+		t.Error(ErrExpectedNil)
+	}
+
+	jt.Value.Set(expected)
+	if jt.Value.IsNil() {
+		t.Error(ErrExpectedValue)
+	}
+	if jt.Value.Value() != expected {
+		t.Errorf(ErrExpectedJSONString, expected, jt.Value.Value())
+	}
+}
+
 func ExampleVariable_UnmarshalJSON() {
 	type JSONType struct {
 		Bool       NilBoolean   `json:"bool"`


### PR DESCRIPTION
- Added the `Set` method to the `Variable` type to set a value and mark it as valid.
- Added a test case `TestVariable_Set` to verify the correctness of the `Set` method functionality.